### PR TITLE
fix some mistakes in encode_blocks.py and  embed_blocks.py

### DIFF
--- a/nlp/embed_blocks.py
+++ b/nlp/embed_blocks.py
@@ -46,6 +46,7 @@ def Positional_embed(batch_size,
 
 def SinusPositional_embed(batch_size,
                           seq_length,
+                          max_seq_len,
                           num_units,
                           zero_pad=True,
                           scale=True,
@@ -70,7 +71,7 @@ def SinusPositional_embed(batch_size,
         # First part of the PE function: sin and cos argument
         position_enc = np.array([
             [pos / np.power(10000, 2. * i / num_units) for i in range(num_units)]
-            for pos in range(seq_length)])
+            for pos in range(max_seq_len)])
 
         # Second part, apply the cosine to even columns and sin to odds.
         position_enc[:, 0::2] = np.sin(position_enc[:, 0::2])  # dim 2i

--- a/nlp/encode_blocks.py
+++ b/nlp/encode_blocks.py
@@ -39,7 +39,7 @@ def Res_DualCNN_encode(seqs, use_spatial_dropout=True, scope='res_biconv_block',
             out1 = spatial_dropout(out1)
         out2 = CNN_encode(out1, scope='second_conv1d', **kwargs)
         if use_spatial_dropout:
-            out2 = CNN_encode(out2)
+            out2 = spatial_dropout(out2)
         return dropout_res_layernorm(seqs, out2, **kwargs)
 
 


### PR DESCRIPTION
1. if use_spatial_dropout == True, apply spatial_dropout to out2.
2. use max_seq_len to create lookup_table instead of seq_length.